### PR TITLE
fonts: add typefaces used by juspay/olai

### DIFF
--- a/pkgs/atkinson-hyperlegible-next/default.nix
+++ b/pkgs/atkinson-hyperlegible-next/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  installFonts,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "atkinson-hyperlegible-next";
+  version = "2.001-unstable-2025-02-21";
+
+  outputs = [
+    "out"
+    "webfont"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "googlefonts";
+    repo = "atkinson-hyperlegible-next";
+    rev = "7925f50f649b3813257faf2f4c0b381011f434f1";
+    hash = "sha256-LhwfYI5Z6BhO7OaY/RwXT7r3WYiUY9AO2HL3MmhPpQY=";
+  };
+
+  dontBuild = true;
+
+  nativeBuildInputs = [ installFonts ];
+
+  # default installPhase invokes python, but we still want the font hook to run
+  installPhase = ''
+    runHook preInstall
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "New (2024) second version of the Atkinson Hyperlegible fonts";
+    homepage = "https://www.brailleinstitute.org/freefont/";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/commit-mono/default.nix
+++ b/pkgs/commit-mono/default.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "commit-mono";
+  version = "1.143";
+
+  src = fetchzip {
+    url = "https://github.com/eigilnikolajsen/commit-mono/releases/download/v${finalAttrs.version}/CommitMono-${finalAttrs.version}.zip";
+    hash = "sha256-JTyPgWfbWq+lXQU/rgnyvPG6+V3f+FB5QUkd+I1oFKE=";
+    stripRoot = false;
+  };
+
+  dontConfigure = true;
+  dontPatch = true;
+  dontBuild = true;
+  dontFixup = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm644 CommitMono-${finalAttrs.version}/*.otf -t $out/share/fonts/opentype
+    install -Dm644 CommitMono-${finalAttrs.version}/ttfautohint/*.ttf -t $out/share/fonts/truetype
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Anonymous and neutral programming typeface focused on creating a better reading experience";
+    homepage = "https://commitmono.com/";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/crimson-pro/default.nix
+++ b/pkgs/crimson-pro/default.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation {
+  pname = "crimson-pro";
+  version = "unstable-2022-08-30";
+
+  outputs = [
+    "out"
+    "woff2"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "Fonthausen";
+    repo = "CrimsonPro";
+    rev = "24e8f7bf59ec45d77c67879ad80d97e5f94c787b";
+    hash = "sha256-3zFB1AMcC7eNEVA2Mx1OE8rLN9zPzexZ3FtER9wH5ss=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -m444 -Dt $out/share/fonts/truetype fonts/ttf/*.ttf
+    install -m444 -Dt $out/share/fonts/opentype fonts/otf/*.otf
+    install -m444 -Dt $woff2/share/fonts/woff2 fonts/webfonts/*.woff2
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/Fonthausen/CrimsonPro";
+    description = "Professionally produced redesign of Crimson by Jacques Le Bailly";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/et-book/default.nix
+++ b/pkgs/et-book/default.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  installFonts,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "et-book";
+  version = "0-unstable-2015-10-05";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  outputs = [
+    "out"
+    "webfont"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "edwardtufte";
+    repo = "et-book";
+    rev = "7e8f02dadcc23ba42b491b39e5bdf16e7b383031";
+    hash = "sha256-B6ryC9ibNop08TJC/w9LSHHwqV/81EezXsTUJFq8xpo=";
+  };
+
+  nativeBuildInputs = [ installFonts ];
+
+  meta = {
+    description = "Typeface used in Edward Tufte’s books";
+    homepage = "https://edwardtufte.github.io/et-book/";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/geist-font/default.nix
+++ b/pkgs/geist-font/default.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+  installFonts,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "geist-font";
+  version = "1.5.0";
+
+  srcs = [
+    (fetchzip {
+      url = "https://github.com/vercel/geist-font/releases/download/${finalAttrs.version}/geist-font-${finalAttrs.version}.zip";
+      hash = "sha256-p3nFuaQPvw4PLcb5AOhu9jiNCTzZD7st1MuJKTAzwKE=";
+    })
+  ];
+
+  sourceRoot = ".";
+
+  outputs = [
+    "out"
+    "webfont"
+  ];
+
+  nativeBuildInputs = [ installFonts ];
+
+  meta = {
+    description = "Font family created by Vercel in collaboration with Basement Studio";
+    homepage = "https://vercel.com/font";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/ia-writer-mono/default.nix
+++ b/pkgs/ia-writer-mono/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "ia-writer-mono";
+  version = "0-unstable-2023-06-16";
+
+  src = fetchFromGitHub {
+    owner = "iaolo";
+    repo = "iA-Fonts";
+    rev = "f32c04c3058a75d7ce28919ce70fe8800817491b";
+    hash = "sha256-2T165nFfCzO65/PIHauJA//S+zug5nUwPcg8NUEydfc=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/fonts/truetype
+    cp iA\ Writer\ Mono/Variable/*.ttf $out/share/fonts/truetype
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "iA Writer Mono Typeface";
+    homepage = "https://ia.net/topics/in-search-of-the-perfect-writing-font";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/ia-writer-quattro/default.nix
+++ b/pkgs/ia-writer-quattro/default.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "ia-writer-quattro";
+  version = "0-unstable-2023-06-16";
+
+  src = fetchFromGitHub {
+    owner = "iaolo";
+    rev = "f32c04c3058a75d7ce28919ce70fe8800817491b";
+    repo = "iA-fonts";
+    hash = "sha256-2T165nFfCzO65/PIHauJA//S+zug5nUwPcg8NUEydfc=";
+  };
+
+  dontConfigure = true;
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/fonts/truetype
+    cp -R $src/iA\ Writer\ Quattro/Static/*.ttf $out/share/fonts/truetype
+    cp -R $src/iA\ Writer\ Quattro/Variable/*.ttf $out/share/fonts/truetype
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "iA Writer Quattro Typeface";
+    homepage = "https://github.com/iaolo/iA-Fonts";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/lexend/default.nix
+++ b/pkgs/lexend/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "lexend";
+  version = "0.pre+date=2022-09-22";
+
+  src = fetchFromGitHub {
+    owner = "googlefonts";
+    repo = "lexend";
+    rev = "cd26b9c2538d758138c20c3d2f10362ed613854b";
+    hash = "sha256-ZKogntyJ/44GBZmFwbtw5Ujw5Gnvv0tVB59ciKqR4c8=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    cd fonts
+    for f in *; do
+      install -D -t $out/share/fonts/truetype/lexend/$f $f/ttf/*
+      install -D -t $out/share/fonts/variable/lexend/$f $f/variable/*
+    done
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://www.lexend.com";
+    description = "Variable font family designed to aid in reading proficiency";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/literata/default.nix
+++ b/pkgs/literata/default.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+  installFonts,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "literata";
+  version = "3.103";
+
+  outputs = [
+    "out"
+    "webfont"
+  ];
+
+  src = fetchzip {
+    url = "https://github.com/googlefonts/literata/releases/download/${finalAttrs.version}/${finalAttrs.version}.zip";
+    hash = "sha256-XwwvyzwO2uhi1Bay9HtB75j1QfAJR4TMETgy/zyvwZ0=";
+    stripRoot = false;
+  };
+
+  nativeBuildInputs = [ installFonts ];
+
+  meta = {
+    description = "Serif typeface designed for ebooks and optimized for reading";
+    homepage = "https://github.com/googlefonts/literata";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/vollkorn/default.nix
+++ b/pkgs/vollkorn/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+  installFonts,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "vollkorn";
+  version = "4.105";
+
+  outputs = [
+    "out"
+    "webfont"
+    "doc"
+  ];
+
+  src = fetchzip {
+    url = "http://vollkorn-typeface.com/download/vollkorn-${
+      builtins.replaceStrings [ "." ] [ "-" ] finalAttrs.version
+    }.zip";
+    stripRoot = false;
+    hash = "sha256-oG79GgCwCavbMFAPakza08IPmt13Gwujrkc/NKTai7g=";
+  };
+
+  nativeBuildInputs = [ installFonts ];
+
+  postInstall = ''
+    install -Dm444 {Fontlog,OFL-FAQ,OFL}.txt -t $doc/share/doc/${finalAttrs.pname}-${finalAttrs.version}/
+  '';
+
+  meta = {
+    homepage = "http://vollkorn-typeface.com/";
+    description = "Free and healthy typeface for bread and butter use";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
These fonts are needed by [juspay/olai](https://github.com/juspay/olai) ([PR #527](https://github.com/juspay/olai/pull/527)), which is migrating off nixpkgs onto ekapkgs.

None of these packages exist on ekapkgs master today. Expressions follow existing ekapkgs font packages (`fira-code`, `open-sans`): they live at `pkgs/<name>/default.nix`, use `stdenvNoCC`/`fetchzip`/`fetchFromGitHub`/`installFonts` as appropriate, omit `lib.maintainers`, and set `meta.platforms = lib.platforms.all`.

Install paths are kept compatible with nixpkgs so olai's hosted font lookups continue to work.

Packages added:

- `literata` 3.103
- `ia-writer-quattro` 0-unstable-2023-06-16
- `ia-writer-mono` 0-unstable-2023-06-16
- `atkinson-hyperlegible-next` 2.001-unstable-2025-02-21
- `et-book` 0-unstable-2015-10-05
- `geist-font` 1.5.0
- `lexend` 0.pre+date=2022-09-22
- `crimson-pro` unstable-2022-08-30
- `vollkorn` 4.105
- `commit-mono` 1.143

Each attribute evaluates with `nix-instantiate -A <name>`.