### PR TITLE
playwright-driver: init at 1.61.1

### DIFF
--- a/pkgs/playwright-driver/browser-downloads.nix
+++ b/pkgs/playwright-driver/browser-downloads.nix
@@ -1,0 +1,51 @@
+{
+  name,
+  revision,
+  browserVersion ? "",
+}:
+let
+  cftUrl =
+    path:
+    assert browserVersion != "";
+    "https://cdn.playwright.dev/builds/cft/${browserVersion}/${path}";
+
+  registryUrl =
+    browser: archive:
+    "https://cdn.playwright.dev/dbazure/download/playwright/builds/${browser}/${revision}/${archive}";
+
+  mk = url: stripRoot: {
+    inherit url stripRoot;
+  };
+in
+{
+  chromium = {
+    x86_64-linux = mk (cftUrl "linux64/chrome-linux64.zip") true;
+    aarch64-linux = mk (registryUrl "chromium" "chromium-linux-arm64.zip") true;
+    aarch64-darwin = mk (cftUrl "mac-arm64/chrome-mac-arm64.zip") false;
+  };
+
+  "chromium-headless-shell" = {
+    x86_64-linux = mk (cftUrl "linux64/chrome-headless-shell-linux64.zip") false;
+    aarch64-linux = mk (registryUrl "chromium" "chromium-headless-shell-linux-arm64.zip") false;
+    aarch64-darwin = mk (cftUrl "mac-arm64/chrome-headless-shell-mac-arm64.zip") false;
+  };
+
+  firefox = {
+    x86_64-linux = mk (registryUrl "firefox" "firefox-ubuntu-24.04.zip") true;
+    aarch64-linux = mk (registryUrl "firefox" "firefox-ubuntu-24.04-arm64.zip") true;
+    aarch64-darwin = mk (registryUrl "firefox" "firefox-mac-arm64.zip") false;
+  };
+
+  webkit = {
+    x86_64-linux = mk (registryUrl "webkit" "webkit-ubuntu-24.04.zip") false;
+    aarch64-linux = mk (registryUrl "webkit" "webkit-ubuntu-24.04-arm64.zip") false;
+    aarch64-darwin = mk (registryUrl "webkit" "webkit-mac-15-arm64.zip") false;
+  };
+
+  ffmpeg = {
+    x86_64-linux = mk (registryUrl "ffmpeg" "ffmpeg-linux.zip") false;
+    aarch64-linux = mk (registryUrl "ffmpeg" "ffmpeg-linux-arm64.zip") false;
+    aarch64-darwin = mk (registryUrl "ffmpeg" "ffmpeg-mac-arm64.zip") false;
+  };
+}
+.${name}

--- a/pkgs/playwright-driver/browser-downloads.nix
+++ b/pkgs/playwright-driver/browser-downloads.nix
@@ -1,51 +1,42 @@
-{
-  name,
-  revision,
-  browserVersion ? "",
+{ name
+, revision
+, browserVersion ? ""
+,
 }:
 let
   cftUrl =
     path:
-    assert browserVersion != "";
-    "https://cdn.playwright.dev/builds/cft/${browserVersion}/${path}";
+      assert browserVersion != "";
+      "https://cdn.playwright.dev/builds/cft/${browserVersion}/${path}";
 
   registryUrl =
     browser: archive:
     "https://cdn.playwright.dev/dbazure/download/playwright/builds/${browser}/${revision}/${archive}";
 
-  mk = url: stripRoot: {
-    inherit url stripRoot;
+  mk = url: stripRoot: hash: {
+    inherit
+      url
+      stripRoot
+      hash
+      ;
   };
 in
 {
   chromium = {
-    x86_64-linux = mk (cftUrl "linux64/chrome-linux64.zip") true;
-    aarch64-linux = mk (registryUrl "chromium" "chromium-linux-arm64.zip") true;
-    aarch64-darwin = mk (cftUrl "mac-arm64/chrome-mac-arm64.zip") false;
+    x86_64-linux = mk (cftUrl "linux64/chrome-linux64.zip") true "sha256-/0OwT0Asm4A/rUkFruw1JYWbDInFJPuDX0CEdNjeMLo=";
+    aarch64-linux = mk (registryUrl "chromium" "chromium-linux-arm64.zip") true "sha256-5vNF1/utXGctixYJj/0qvi6X0qklIG9XCcet94feQoA=";
+    aarch64-darwin = mk (cftUrl "mac-arm64/chrome-mac-arm64.zip") false "sha256-aJbvZQ1hY0FfDC+ZktfW2yNW3nwc0kh/P30+n/cmLf0=";
   };
 
   "chromium-headless-shell" = {
-    x86_64-linux = mk (cftUrl "linux64/chrome-headless-shell-linux64.zip") false;
-    aarch64-linux = mk (registryUrl "chromium" "chromium-headless-shell-linux-arm64.zip") false;
-    aarch64-darwin = mk (cftUrl "mac-arm64/chrome-headless-shell-mac-arm64.zip") false;
-  };
-
-  firefox = {
-    x86_64-linux = mk (registryUrl "firefox" "firefox-ubuntu-24.04.zip") true;
-    aarch64-linux = mk (registryUrl "firefox" "firefox-ubuntu-24.04-arm64.zip") true;
-    aarch64-darwin = mk (registryUrl "firefox" "firefox-mac-arm64.zip") false;
-  };
-
-  webkit = {
-    x86_64-linux = mk (registryUrl "webkit" "webkit-ubuntu-24.04.zip") false;
-    aarch64-linux = mk (registryUrl "webkit" "webkit-ubuntu-24.04-arm64.zip") false;
-    aarch64-darwin = mk (registryUrl "webkit" "webkit-mac-15-arm64.zip") false;
+    x86_64-linux = mk (cftUrl "linux64/chrome-headless-shell-linux64.zip") false "sha256-wnN0SL8QqiFGZdevm06WOhR9o6q34+kHL5ay1mRYnxs=";
+    aarch64-linux = mk (registryUrl "chromium" "chromium-headless-shell-linux-arm64.zip") false "sha256-d9Qr3q4GjtUp2ZVFSq+M2Ap++WKaEscRzEkk4JwXL/E=";
+    aarch64-darwin = mk (cftUrl "mac-arm64/chrome-headless-shell-mac-arm64.zip") false "sha256-qWrMOreqTOFhmFBROlXIPXrM3wqNT7iJJwpelVFke6I=";
   };
 
   ffmpeg = {
-    x86_64-linux = mk (registryUrl "ffmpeg" "ffmpeg-linux.zip") false;
-    aarch64-linux = mk (registryUrl "ffmpeg" "ffmpeg-linux-arm64.zip") false;
-    aarch64-darwin = mk (registryUrl "ffmpeg" "ffmpeg-mac-arm64.zip") false;
+    x86_64-linux = mk (registryUrl "ffmpeg" "ffmpeg-linux.zip") false "sha256-AWTiui+ccKHxsIaQSgc5gWCJT5gYwIWzAEqSuKgVqZU=";
+    aarch64-linux = mk (registryUrl "ffmpeg" "ffmpeg-linux-arm64.zip") false "sha256-1mOKO2lcnlwLsC6ob//xKnKrCOp94pw8X14uBxCdj0Q=";
+    aarch64-darwin = mk (registryUrl "ffmpeg" "ffmpeg-mac-arm64.zip") false "sha256-ky10UQj+XPVGpaWAPvKd51C5brml0y9xQ6iKcrxAMRc=";
   };
-}
-.${name}
+}.${name}

--- a/pkgs/playwright-driver/browsers.json
+++ b/pkgs/playwright-driver/browsers.json
@@ -1,5 +1,5 @@
 {
-  "comment": "Playwright 1.61.1 browsers.json (chromium farm only; firefox/webkit URLs unused)",
+  "comment": "Playwright 1.61.1 chromium farm (revision pin only; FODs live in browser-downloads.nix)",
   "browsers": {
     "chromium": {
       "revision": "1228",
@@ -10,24 +10,6 @@
       "revision": "1228",
       "browserVersion": "149.0.7827.55",
       "title": "Chrome Headless Shell"
-    },
-    "firefox": {
-      "revision": "1532",
-      "browserVersion": "151.0",
-      "title": "Firefox"
-    },
-    "webkit": {
-      "revision": "2311",
-      "revisionOverrides": {
-        "mac14": "2251",
-        "mac14-arm64": "2251",
-        "debian11-x64": "2105",
-        "debian11-arm64": "2105",
-        "ubuntu20.04-x64": "2092",
-        "ubuntu20.04-arm64": "2092"
-      },
-      "browserVersion": "26.5",
-      "title": "WebKit"
     },
     "ffmpeg": {
       "revision": "1011",

--- a/pkgs/playwright-driver/browsers.json
+++ b/pkgs/playwright-driver/browsers.json
@@ -1,0 +1,40 @@
+{
+  "comment": "Playwright 1.61.1 browsers.json (chromium farm only; firefox/webkit URLs unused)",
+  "browsers": {
+    "chromium": {
+      "revision": "1228",
+      "browserVersion": "149.0.7827.55",
+      "title": "Chrome for Testing"
+    },
+    "chromium-headless-shell": {
+      "revision": "1228",
+      "browserVersion": "149.0.7827.55",
+      "title": "Chrome Headless Shell"
+    },
+    "firefox": {
+      "revision": "1532",
+      "browserVersion": "151.0",
+      "title": "Firefox"
+    },
+    "webkit": {
+      "revision": "2311",
+      "revisionOverrides": {
+        "mac14": "2251",
+        "mac14-arm64": "2251",
+        "debian11-x64": "2105",
+        "debian11-arm64": "2105",
+        "ubuntu20.04-x64": "2092",
+        "ubuntu20.04-arm64": "2092"
+      },
+      "browserVersion": "26.5",
+      "title": "WebKit"
+    },
+    "ffmpeg": {
+      "revision": "1011",
+      "revisionOverrides": {
+        "mac12": "1010",
+        "mac12-arm64": "1010"
+      }
+    }
+  }
+}

--- a/pkgs/playwright-driver/chromium-headless-shell.nix
+++ b/pkgs/playwright-driver/chromium-headless-shell.nix
@@ -1,27 +1,25 @@
-{
-  fetchzip,
-  revision,
-  browserVersion,
-  system,
-  throwSystem,
-  stdenv,
-  autoPatchelfHook,
-  patchelf,
-
-  alsa-lib,
-  at-spi2-atk,
-  expat,
-  glib,
-  libxcomposite,
-  libxdamage,
-  libxfixes,
-  libxrandr,
-  libgbm,
-  libgcc,
-  libxkbcommon,
-  nspr,
-  nss,
-  ...
+{ fetchzip
+, revision
+, browserVersion
+, system
+, throwSystem
+, stdenv
+, autoPatchelfHook
+, patchelf
+, alsa-lib
+, at-spi2-atk
+, expat
+, glib
+, libxcomposite
+, libxdamage
+, libxfixes
+, libxrandr
+, libgbm
+, libgcc
+, libxkbcommon
+, nspr
+, nss
+, ...
 }:
 let
   download =
@@ -33,13 +31,7 @@ let
   linux = stdenv.mkDerivation {
     name = "playwright-chromium-headless-shell";
     src = fetchzip {
-      inherit (download) url stripRoot;
-      hash =
-        {
-          x86_64-linux = "sha256-wnN0SL8QqiFGZdevm06WOhR9o6q34+kHL5ay1mRYnxs=";
-          aarch64-linux = "sha256-d9Qr3q4GjtUp2ZVFSq+M2Ap++WKaEscRzEkk4JwXL/E=";
-        }
-        .${system} or throwSystem;
+      inherit (download) url stripRoot hash;
     };
 
     nativeBuildInputs = [
@@ -69,13 +61,11 @@ let
   };
 
   darwin = fetchzip {
-    inherit (download) url stripRoot;
-    hash = "sha256-qWrMOreqTOFhmFBROlXIPXrM3wqNT7iJJwpelVFke6I=";
+    inherit (download) url stripRoot hash;
   };
 in
-{
-  x86_64-linux = linux;
-  aarch64-linux = linux;
-  aarch64-darwin = darwin;
-}
-.${system} or throwSystem
+  {
+    x86_64-linux = linux;
+    aarch64-linux = linux;
+    aarch64-darwin = darwin;
+  }.${system} or throwSystem

--- a/pkgs/playwright-driver/chromium-headless-shell.nix
+++ b/pkgs/playwright-driver/chromium-headless-shell.nix
@@ -1,0 +1,81 @@
+{
+  fetchzip,
+  revision,
+  browserVersion,
+  system,
+  throwSystem,
+  stdenv,
+  autoPatchelfHook,
+  patchelf,
+
+  alsa-lib,
+  at-spi2-atk,
+  expat,
+  glib,
+  libxcomposite,
+  libxdamage,
+  libxfixes,
+  libxrandr,
+  libgbm,
+  libgcc,
+  libxkbcommon,
+  nspr,
+  nss,
+  ...
+}:
+let
+  download =
+    (import ./browser-downloads.nix {
+      name = "chromium-headless-shell";
+      inherit revision browserVersion;
+    }).${system} or throwSystem;
+
+  linux = stdenv.mkDerivation {
+    name = "playwright-chromium-headless-shell";
+    src = fetchzip {
+      inherit (download) url stripRoot;
+      hash =
+        {
+          x86_64-linux = "sha256-wnN0SL8QqiFGZdevm06WOhR9o6q34+kHL5ay1mRYnxs=";
+          aarch64-linux = "sha256-d9Qr3q4GjtUp2ZVFSq+M2Ap++WKaEscRzEkk4JwXL/E=";
+        }
+        .${system} or throwSystem;
+    };
+
+    nativeBuildInputs = [
+      autoPatchelfHook
+      patchelf
+    ];
+
+    buildInputs = [
+      alsa-lib
+      at-spi2-atk
+      expat
+      glib
+      libxcomposite
+      libxdamage
+      libxfixes
+      libxrandr
+      libgbm
+      libgcc
+      libxkbcommon
+      nspr
+      nss
+    ];
+
+    buildPhase = ''
+      cp -R . $out
+    '';
+  };
+
+  darwin = fetchzip {
+    inherit (download) url stripRoot;
+    hash = "sha256-qWrMOreqTOFhmFBROlXIPXrM3wqNT7iJJwpelVFke6I=";
+  };
+in
+{
+  x86_64-linux = linux;
+  aarch64-linux = linux;
+  aarch64-darwin = darwin;
+}
+.${system} or throwSystem

--- a/pkgs/playwright-driver/chromium.nix
+++ b/pkgs/playwright-driver/chromium.nix
@@ -1,0 +1,138 @@
+{
+  runCommand,
+  makeWrapper,
+  fontconfig_file,
+  fetchzip,
+  revision,
+  browserVersion,
+  system,
+  throwSystem,
+  lib,
+  alsa-lib,
+  at-spi2-atk,
+  atk,
+  autoPatchelfHook,
+  cairo,
+  cups,
+  dbus,
+  expat,
+  glib,
+  gobject-introspection,
+  libGL,
+  libgbm,
+  libgcc,
+  libxkbcommon,
+  nspr,
+  nss,
+  pango,
+  patchelf,
+  pciutils,
+  stdenv,
+  systemd,
+  vulkan-loader,
+  libxrandr,
+  libxfixes,
+  libxext,
+  libxdamage,
+  libxcomposite,
+  libx11,
+  libxcb,
+  ...
+}:
+let
+  download =
+    (import ./browser-downloads.nix {
+      name = "chromium";
+      inherit revision browserVersion;
+    }).${system} or throwSystem;
+
+  # Playwright expects different directory names for different architectures:
+  # - linux-x64 expects: chrome-linux64
+  # - linux-arm64 expects: chrome-linux
+  chromeDir =
+    {
+      x86_64-linux = "chrome-linux64";
+      aarch64-linux = "chrome-linux";
+    }
+    .${system} or throwSystem;
+
+  chromium-linux = stdenv.mkDerivation {
+    name = "playwright-chromium";
+    src = fetchzip {
+      inherit (download) url stripRoot;
+      hash =
+        {
+          x86_64-linux = "sha256-/0OwT0Asm4A/rUkFruw1JYWbDInFJPuDX0CEdNjeMLo=";
+          aarch64-linux = "sha256-5vNF1/utXGctixYJj/0qvi6X0qklIG9XCcet94feQoA=";
+        }
+        .${system} or throwSystem;
+    };
+
+    nativeBuildInputs = [
+      autoPatchelfHook
+      patchelf
+      makeWrapper
+    ];
+    buildInputs = [
+      alsa-lib
+      at-spi2-atk
+      atk
+      cairo
+      cups
+      dbus
+      expat
+      glib
+      gobject-introspection
+      libgbm
+      libgcc
+      libxkbcommon
+      nspr
+      nss
+      pango
+      stdenv.cc.cc.lib
+      systemd
+      libx11
+      libxcomposite
+      libxdamage
+      libxext
+      libxfixes
+      libxrandr
+      libxcb
+    ];
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/${chromeDir}
+      cp -R . $out/${chromeDir}
+
+      wrapProgram $out/${chromeDir}/chrome \
+        --set-default SSL_CERT_FILE /etc/ssl/certs/ca-bundle.crt \
+        --set-default FONTCONFIG_FILE ${fontconfig_file}
+
+      runHook postInstall
+    '';
+
+    appendRunpaths = lib.makeLibraryPath [
+      libGL
+      vulkan-loader
+      pciutils
+    ];
+
+    postFixup = ''
+      # replace bundled vulkan-loader since we are also already adding our own to RPATH
+      rm "$out/${chromeDir}/libvulkan.so.1"
+      ln -s -t "$out/${chromeDir}" "${lib.getLib vulkan-loader}/lib/libvulkan.so.1"
+    '';
+  };
+  chromium-darwin = fetchzip {
+    inherit (download) url stripRoot;
+    hash = "sha256-aJbvZQ1hY0FfDC+ZktfW2yNW3nwc0kh/P30+n/cmLf0=";
+  };
+in
+{
+  x86_64-linux = chromium-linux;
+  aarch64-linux = chromium-linux;
+  aarch64-darwin = chromium-darwin;
+}
+.${system} or throwSystem

--- a/pkgs/playwright-driver/chromium.nix
+++ b/pkgs/playwright-driver/chromium.nix
@@ -1,43 +1,42 @@
-{
-  runCommand,
-  makeWrapper,
-  fontconfig_file,
-  fetchzip,
-  revision,
-  browserVersion,
-  system,
-  throwSystem,
-  lib,
-  alsa-lib,
-  at-spi2-atk,
-  atk,
-  autoPatchelfHook,
-  cairo,
-  cups,
-  dbus,
-  expat,
-  glib,
-  gobject-introspection,
-  libGL,
-  libgbm,
-  libgcc,
-  libxkbcommon,
-  nspr,
-  nss,
-  pango,
-  patchelf,
-  pciutils,
-  stdenv,
-  systemd,
-  vulkan-loader,
-  libxrandr,
-  libxfixes,
-  libxext,
-  libxdamage,
-  libxcomposite,
-  libx11,
-  libxcb,
-  ...
+{ runCommand
+, makeWrapper
+, fontconfig_file
+, fetchzip
+, revision
+, browserVersion
+, system
+, throwSystem
+, lib
+, alsa-lib
+, at-spi2-atk
+, atk
+, autoPatchelfHook
+, cairo
+, cups
+, dbus
+, expat
+, glib
+, gobject-introspection
+, libGL
+, libgbm
+, libgcc
+, libxkbcommon
+, nspr
+, nss
+, pango
+, patchelf
+, pciutils
+, stdenv
+, systemd
+, vulkan-loader
+, libxrandr
+, libxfixes
+, libxext
+, libxdamage
+, libxcomposite
+, libx11
+, libxcb
+, ...
 }:
 let
   download =
@@ -53,19 +52,12 @@ let
     {
       x86_64-linux = "chrome-linux64";
       aarch64-linux = "chrome-linux";
-    }
-    .${system} or throwSystem;
+    }.${system} or throwSystem;
 
   chromium-linux = stdenv.mkDerivation {
     name = "playwright-chromium";
     src = fetchzip {
-      inherit (download) url stripRoot;
-      hash =
-        {
-          x86_64-linux = "sha256-/0OwT0Asm4A/rUkFruw1JYWbDInFJPuDX0CEdNjeMLo=";
-          aarch64-linux = "sha256-5vNF1/utXGctixYJj/0qvi6X0qklIG9XCcet94feQoA=";
-        }
-        .${system} or throwSystem;
+      inherit (download) url stripRoot hash;
     };
 
     nativeBuildInputs = [
@@ -126,13 +118,11 @@ let
     '';
   };
   chromium-darwin = fetchzip {
-    inherit (download) url stripRoot;
-    hash = "sha256-aJbvZQ1hY0FfDC+ZktfW2yNW3nwc0kh/P30+n/cmLf0=";
+    inherit (download) url stripRoot hash;
   };
 in
-{
-  x86_64-linux = chromium-linux;
-  aarch64-linux = chromium-linux;
-  aarch64-darwin = chromium-darwin;
-}
-.${system} or throwSystem
+  {
+    x86_64-linux = chromium-linux;
+    aarch64-linux = chromium-linux;
+    aarch64-darwin = chromium-darwin;
+  }.${system} or throwSystem

--- a/pkgs/playwright-driver/default.nix
+++ b/pkgs/playwright-driver/default.nix
@@ -6,13 +6,13 @@
 # Chromium-only: firefox-bin is missing from this set and webkit's closure
 # is huge. Consumers that only launch chromium (typical Node e2e) use
 # passthru.browsers.
-{
-  lib,
-  callPackage,
-  linkFarm,
-  runCommand,
-  makeFontsConf,
-  stdenv,
+{ lib
+, callPackage
+, linkFarm
+, runCommand
+, makeFontsConf
+, stdenv
+,
 }:
 let
   version = "1.61.1";

--- a/pkgs/playwright-driver/default.nix
+++ b/pkgs/playwright-driver/default.nix
@@ -1,0 +1,66 @@
+# Playwright's chromium browser set (FODs from cdn.playwright.dev), not a
+# source-built Chromium or ffmpeg. The inner chrome / headless-shell / ffmpeg
+# zips are Playwright-revision-pinned blobs for PLAYWRIGHT_BROWSERS_PATH;
+# they are not pkgs.chromium / pkgs.ffmpeg.
+#
+# Chromium-only: firefox-bin is missing from this set and webkit's closure
+# is huge. Consumers that only launch chromium (typical Node e2e) use
+# passthru.browsers.
+{
+  lib,
+  callPackage,
+  linkFarm,
+  runCommand,
+  makeFontsConf,
+  stdenv,
+}:
+let
+  version = "1.61.1";
+  inherit (stdenv.hostPlatform) system;
+  throwSystem = throw "Unsupported system: ${system}";
+  browsersJSON = (lib.importJSON ./browsers.json).browsers;
+  fontconfig_file = makeFontsConf { fontDirectories = [ ]; };
+
+  components = {
+    chromium = callPackage ./chromium.nix {
+      inherit system throwSystem fontconfig_file;
+      inherit (browsersJSON.chromium) revision browserVersion;
+    };
+    chromium-headless-shell = callPackage ./chromium-headless-shell.nix {
+      inherit system throwSystem;
+      inherit (browsersJSON."chromium-headless-shell") revision browserVersion;
+    };
+    ffmpeg = callPackage ./ffmpeg.nix {
+      inherit system throwSystem;
+      inherit (browsersJSON.ffmpeg) revision;
+    };
+  };
+
+  browsers = linkFarm "playwright-browsers" (
+    lib.listToAttrs (
+      map
+        (name:
+          lib.nameValuePair
+            "${lib.replaceStrings [ "-" ] [ "_" ] name}-${browsersJSON.${name}.revision}"
+            components.${name})
+        [ "chromium" "chromium-headless-shell" "ffmpeg" ]
+    )
+  );
+in
+runCommand "playwright-driver"
+{
+  passthru = {
+    inherit browsers version;
+  };
+  meta = {
+    description = "Playwright ${version} chromium browsers";
+    homepage = "https://playwright.dev";
+    # Chrome for Testing is Google Chrome.
+    license = lib.licenses.unfree;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
+  };
+} "mkdir -p $out"

--- a/pkgs/playwright-driver/ffmpeg.nix
+++ b/pkgs/playwright-driver/ffmpeg.nix
@@ -1,0 +1,24 @@
+# Playwright's pinned ffmpeg blob for trace/video, not pkgs.ffmpeg.
+{
+  fetchzip,
+  revision,
+  system,
+  throwSystem,
+}:
+let
+  download =
+    (import ./browser-downloads.nix {
+      name = "ffmpeg";
+      inherit revision;
+    }).${system} or throwSystem;
+in
+fetchzip {
+  inherit (download) url stripRoot;
+  hash =
+    {
+      x86_64-linux = "sha256-AWTiui+ccKHxsIaQSgc5gWCJT5gYwIWzAEqSuKgVqZU=";
+      aarch64-linux = "sha256-1mOKO2lcnlwLsC6ob//xKnKrCOp94pw8X14uBxCdj0Q=";
+      aarch64-darwin = "sha256-ky10UQj+XPVGpaWAPvKd51C5brml0y9xQ6iKcrxAMRc=";
+    }
+    .${system} or throwSystem;
+}

--- a/pkgs/playwright-driver/ffmpeg.nix
+++ b/pkgs/playwright-driver/ffmpeg.nix
@@ -1,9 +1,9 @@
 # Playwright's pinned ffmpeg blob for trace/video, not pkgs.ffmpeg.
-{
-  fetchzip,
-  revision,
-  system,
-  throwSystem,
+{ fetchzip
+, revision
+, system
+, throwSystem
+,
 }:
 let
   download =
@@ -13,12 +13,5 @@ let
     }).${system} or throwSystem;
 in
 fetchzip {
-  inherit (download) url stripRoot;
-  hash =
-    {
-      x86_64-linux = "sha256-AWTiui+ccKHxsIaQSgc5gWCJT5gYwIWzAEqSuKgVqZU=";
-      aarch64-linux = "sha256-1mOKO2lcnlwLsC6ob//xKnKrCOp94pw8X14uBxCdj0Q=";
-      aarch64-darwin = "sha256-ky10UQj+XPVGpaWAPvKd51C5brml0y9xQ6iKcrxAMRc=";
-    }
-    .${system} or throwSystem;
+  inherit (download) url stripRoot hash;
 }


### PR DESCRIPTION
Chromium-only Playwright browser set for `PLAYWRIGHT_BROWSERS_PATH`, the same shape nixpkgs calls `playwright-driver`.

This is **not** a source-built Chromium or ffmpeg. The inner chrome / headless-shell / ffmpeg zips are Playwright-revision-pinned FODs from `cdn.playwright.dev` (Playwright 1.61.1, chromium rev 1228). They stay private to this package; they should not become `pkgs.chromium` or `pkgs.ffmpeg`.

Firefox/webkit are omitted: `firefox-bin` is not in this set, and webkit's closure is huge. Consumers that only launch chromium (typical Node e2e) use `passthru.browsers`.

Lifted from [juspay/olai#527](https://github.com/juspay/olai/pull/527)'s vendor overlay, where `nix build .#olai` and the e2e shell already use it on x86_64-linux and aarch64-darwin.

Chrome for Testing is unfree.